### PR TITLE
ENH: Example how to use dynamic properties and stylesheets

### DIFF
--- a/Applications/ctkDICOMVisualBrowser/ctkDICOMVisualBrowserMain.cpp
+++ b/Applications/ctkDICOMVisualBrowser/ctkDICOMVisualBrowserMain.cpp
@@ -118,5 +118,50 @@ int main(int argc, char** argv)
   mainWidget.show();
   DICOMVisualBrowser.onShowPatients();
 
+  // CTK should define these styles in files like ctkLightStyle.qss
+  QString barebonesLightStyleExample =
+    R""""(
+      ctkSearchBox[warning=true]
+      {
+        background-color: #9c9c27;
+      }
+
+      ctkCheckableComboBox[warning=true]
+      {
+        background-color: #9c9c27;
+      }
+
+      ctkComboBox[warning=true]
+      {
+        background-color: #9c9c27;
+      }
+    )"""";
+
+  QString barebonesDarkStyleExample =
+    R""""(
+      QWidget
+      {
+        background-color: #333333;
+        color: #ffffff;
+      }
+
+      ctkSearchBox[warning=true]
+      {
+        background-color: #9c9c27;
+      }
+
+      ctkCheckableComboBox[warning=true]
+      {
+        background-color: #9c9c27;
+      }
+
+      ctkComboBox[warning=true]
+      {
+        background-color: #9c9c27;
+      }
+    )"""";
+
+  app.setStyleSheet(barebonesLightStyleExample);
+
   return app.exec();
 }

--- a/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.cpp
@@ -889,6 +889,7 @@ void ctkDICOMVisualBrowserWidgetPrivate::setBackgroundColorToWidget(QColor color
     return;
   }
 
+  // This will be applied if no styleSheet has been set on the widget
   QPalette pal = widget->palette();
   QComboBox* comboBox = qobject_cast<QComboBox*>(widget);
   if (comboBox)
@@ -900,6 +901,18 @@ void ctkDICOMVisualBrowserWidgetPrivate::setBackgroundColorToWidget(QColor color
     pal.setColor(widget->backgroundRole(), color);
   }
   widget->setPalette(pal);
+
+  // If the widget has a styleSheet, the styleSheet will overrride the palette
+  if (ctkDICOMVisualBrowserWidgetWarningColor == color)
+  {
+    widget->setProperty("warning", true);
+  }
+  else
+  {
+    widget->setProperty("warning", false);
+  }
+  widget->style()->unpolish(widget);
+  widget->style()->polish(widget);
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Bare bones example how to use dynamic properties and stylesheets in CTK to replace QPalette hard coded colors.

This would allow slicer customizations to replace the colors by simply defining them in the styleSheet.

Reference: https://github.com/commontk/CTK/pull/1201